### PR TITLE
fix: installation failed and roocommander version updated

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -8,7 +8,7 @@
   },
   "main": "./dist/index.js",
   "scripts": {
-    "build": "esbuild ./bin/roo-cli.ts --bundle --outfile=dist/bin/roo-cli.js --platform=node --format=esm --external:./package.json",
+    "build": "esbuild ./bin/roo-cli.ts --bundle --outfile=dist/bin/roo-cli.js --platform=node --format=esm --main-fields=module,main --conditions=node --banner:js=\"import { createRequire } from 'module';const require = createRequire(import.meta.url);\" --external:fs-extra --external:chalk --external:inquirer --external:node:* && node ./scripts/copy-templates.mjs",
     "start": "node ./dist/bin/roo-cli.js",
     "dev": "tsc --watch",
     "prepare:publish": "node ./scripts/prepare-publish.mjs",
@@ -33,8 +33,7 @@
   "files": [
     "dist",
     "README.md",
-    "LICENSE",
-    "templates"
+    "LICENSE"
   ],
   "dependencies": {
     "commander": "^13.1.0",

--- a/npm/scripts/copy-templates.mjs
+++ b/npm/scripts/copy-templates.mjs
@@ -1,0 +1,28 @@
+import fs from 'fs-extra';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const sourceRooDir = path.resolve(__dirname, '..', '..', '.roo');
+const sourceRuruDir = path.resolve(__dirname, '..', '..', '.ruru');
+
+const targetBaseDir = path.resolve(__dirname, '..', 'dist', 'templates');
+const targetRooDir = path.join(targetBaseDir, '.roo');
+const targetRuruDir = path.join(targetBaseDir, '.ruru');
+
+try {
+  fs.ensureDirSync(targetBaseDir); // Ensure the base 'templates' directory exists
+  
+  console.log(`Copying from ${sourceRooDir} to ${targetRooDir}`);
+  fs.copySync(sourceRooDir, targetRooDir);
+  
+  console.log(`Copying from ${sourceRuruDir} to ${targetRuruDir}`);
+  fs.copySync(sourceRuruDir, targetRuruDir);
+  
+  console.log('Successfully copied .roo and .ruru template directories.');
+} catch (err) {
+  console.error('Error copying template directories:', err);
+  process.exit(1); // Exit with error code if copy fails
+}

--- a/npm/src/commands/init.ts
+++ b/npm/src/commands/init.ts
@@ -18,7 +18,7 @@ export async function handleInitCommand(): Promise<void> {
 
   // Source paths relative to the compiled JS file in dist/commands/
   // Go up three levels to reach the project root where templates/ should be
-  const templateBaseDir = path.resolve(__dirname, '..', '..', 'templates'); // Go up from dist/commands/ to package root, then into templates
+  const templateBaseDir = path.resolve(__dirname, '..', 'templates'); // Path relative to dist/commands/, assuming templates is in dist/templates/
   const rooSource = path.join(templateBaseDir, '.roo');
   const ruruSource = path.join(templateBaseDir, '.ruru');
 


### PR DESCRIPTION
fix: update version to 7.2.0 and enhance template copying functionality to avoid fail installation on window

 (/Nodist/bin/node_modules/roocommander/dist/bin/roo-cli.js:12 throw Error('Dynamic require of "' + x + '" is not supported'); Error: Dynamic require of "node:events" is not supported)